### PR TITLE
FIX add datasets, check that y contains -1 and 1s and fix cd

### DIFF
--- a/datasets/leukemia.py
+++ b/datasets/leukemia.py
@@ -1,0 +1,27 @@
+from benchopt import BaseDataset
+
+from benchopt import safe_import_context
+
+
+with safe_import_context() as import_ctx:
+    from sklearn.datasets import fetch_openml
+    from sklearn.preprocessing import LabelBinarizer
+
+
+class Dataset(BaseDataset):
+
+    name = "leukemia"
+
+    install_cmd = 'conda'
+    requirements = ['scikit-learn']
+
+    def get_data(self):
+        # Unlike libsvm[leukemia], this dataset corresponds to the whole
+        # leukemia  data with train + test data (72 samples) and not just
+        # the training set.
+        X, y = fetch_openml("leukemia", return_X_y=True)
+        X = X.to_numpy()
+        y = LabelBinarizer().fit_transform(y)[:, 0].astype(X.dtype)
+        data = dict(X=X, y=y)
+
+        return X.shape[1], data

--- a/datasets/leukemia.py
+++ b/datasets/leukemia.py
@@ -21,7 +21,8 @@ class Dataset(BaseDataset):
         # the training set.
         X, y = fetch_openml("leukemia", return_X_y=True)
         X = X.to_numpy()
-        y = LabelBinarizer().fit_transform(y)[:, 0].astype(X.dtype)
+        y = LabelBinarizer(
+            neg_label=-1, pos_label=1).fit_transform(y)[:, 0].astype(X.dtype)
         data = dict(X=X, y=y)
 
         return X.shape[1], data

--- a/datasets/leukemia.py
+++ b/datasets/leukemia.py
@@ -21,8 +21,8 @@ class Dataset(BaseDataset):
         # the training set.
         X, y = fetch_openml("leukemia", return_X_y=True)
         X = X.to_numpy()
-        y = LabelBinarizer(
-            neg_label=-1, pos_label=1).fit_transform(y)[:, 0].astype(X.dtype)
+        binarizer = LabelBinarizer(neg_label=-1, pos_label=1)
+        y = binarizer.fit_transform(y)[:, 0].astype(X.dtype)
         data = dict(X=X, y=y)
 
         return X.shape[1], data

--- a/datasets/libsvm.py
+++ b/datasets/libsvm.py
@@ -1,0 +1,32 @@
+from benchopt import BaseDataset
+
+from benchopt import safe_import_context
+
+
+with safe_import_context() as import_ctx:
+    from libsvmdata import fetch_libsvm
+
+
+class Dataset(BaseDataset):
+
+    name = "libsvm"
+
+    parameters = {
+        'dataset': ["news20.binary", "rcv1.binary"],
+    }
+
+    install_cmd = 'conda'
+    requirements = ['pip:libsvmdata']
+
+    def __init__(self, dataset="bodyfat"):
+        self.dataset = dataset
+        self.X, self.y = None, None
+
+    def get_data(self):
+
+        if self.X is None:
+            self.X, self.y = fetch_libsvm(self.dataset)
+
+        data = dict(X=self.X, y=self.y)
+
+        return self.X.shape[1], data

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -1,4 +1,5 @@
-from benchopt import BaseDataset
+from benchopt import BaseDataset, safe_import_context
+
 with safe_import_context() as import_ctx:
     from benchopt.datasets import make_correlated_data
 

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -1,4 +1,4 @@
-from benchopt import BaseDataset, safe_import_context
+from benchopt import BaseDataset
 from benchopt.datasets import make_correlated_data
 
 

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -1,5 +1,6 @@
 from benchopt import BaseDataset
-from benchopt.datasets import make_correlated_data
+with safe_import_context() as import_ctx:
+    from benchopt.datasets import make_correlated_data
 
 
 class Dataset(BaseDataset):

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -1,7 +1,5 @@
 from benchopt import BaseDataset, safe_import_context
-
-with safe_import_context() as import_ctx:
-    import numpy as np
+from benchopt.datasets import make_correlated_data
 
 
 class Dataset(BaseDataset):
@@ -10,9 +8,8 @@ class Dataset(BaseDataset):
 
     parameters = {
         'n_samples, n_features': [
-            (100, 5000),
-            (100, 10000),
-            (1000, 10)
+            (500, 2000),
+            (500, 5000),
         ]
     }
 
@@ -22,11 +19,9 @@ class Dataset(BaseDataset):
         self.random_state = random_state
 
     def get_data(self):
-        rng = np.random.RandomState(self.random_state)
-        X = rng.randn(self.n_samples, self.n_features)
-
-        beta = rng.randn(self.n_features)
-        y = np.sign(X @ beta)
+        X, y, _ = make_correlated_data(
+            self.n_samples, self.n_features, random_state=self.random_state)
+        y = 2 * (y > 0) - 1
 
         data = dict(X=X, y=y)
 

--- a/objective.py
+++ b/objective.py
@@ -9,7 +9,7 @@ class Objective(BaseObjective):
 
     parameters = {
         'fit_intercept': [False],
-        'reg': [0.05, .1, .5]
+        'reg': [.5, .1, .05]
     }
 
     def __init__(self, reg=.1, fit_intercept=False):
@@ -17,6 +17,9 @@ class Objective(BaseObjective):
         self.fit_intercept = fit_intercept
 
     def set_data(self, X, y):
+        if set(y) - set([-1, 1]):
+            raise ValueError(
+                "y must contain only -1 or 1 as values. Got %s " % (set(y)))
         self.X, self.y = X, y
         self.lmbd = self.reg * self._get_lambda_max()
 

--- a/objective.py
+++ b/objective.py
@@ -17,9 +17,10 @@ class Objective(BaseObjective):
         self.fit_intercept = fit_intercept
 
     def set_data(self, X, y):
-        if set(y) - set([-1, 1]):
+        if set(y) != set([-1, 1]):
             raise ValueError(
-                "y must contain only -1 or 1 as values. Got %s " % (set(y)))
+                f"y must contain only -1 or 1 as values. Got {set(y)}"
+            )
         self.X, self.y = X, y
         self.lmbd = self.reg * self._get_lambda_max()
 

--- a/solvers/cd.py
+++ b/solvers/cd.py
@@ -49,7 +49,7 @@ class Solver(BaseSolver):
 
     parameters = {
         'newton_step': [False, True],
-        }
+    }
 
     def set_objective(self, X, y, lmbd):
         self.y, self.lmbd = y, lmbd
@@ -86,7 +86,7 @@ class Solver(BaseSolver):
     @njit
     def cd(X, y, lmbd, L, n_iter, newton_step):
         n_samples, n_features = X.shape
-        Xw = np.zeros_like(y)
+        Xw = np.zeros_like(y, dtype=X.dtype)
         w = np.zeros(n_features)
         for _ in range(n_iter):
             for j in range(n_features):


### PR DESCRIPTION
there is an issue with leukemia, I think it's because y has values in {0, 1} while cd, blitz expect them to be in {-1, 1} and don't cast them the way celer or sklearn do.

What the cleanest solution? Cast in the dataset, or in objective.set_data (better for me) ? 